### PR TITLE
feat: Add Epic 2 Stories 2.1 (BE) and 2.5 (FE) with Enum Standards

### DIFF
--- a/docs/architecture/coding-standards.md
+++ b/docs/architecture/coding-standards.md
@@ -155,7 +155,84 @@ export function FlowListInteractive({ initialFlows }) {
 }
 ```
 
-### 7. **Database Query Patterns**
+### 7. **Enum Usage for Type Safety**
+
+**Rule:** ALWAYS use TypeScript enums or const enums for fixed value sets. NEVER use hardcoded string literals for states, statuses, types, or categories.
+
+```typescript
+// ❌ WRONG: Hardcoded string literals
+interface Flow {
+  priority: 'low' | 'medium' | 'high';
+  status: 'pending' | 'in_progress' | 'completed';
+}
+
+const flow = {
+  priority: 'high',  // Typo risk: 'hihg', 'High', etc.
+  status: 'completed'
+};
+
+// ✅ CORRECT: Use enums for type safety
+enum FlowPriority {
+  Low = 'low',
+  Medium = 'medium',
+  High = 'high'
+}
+
+enum FlowStatus {
+  Pending = 'pending',
+  InProgress = 'in_progress',
+  Completed = 'completed'
+}
+
+interface Flow {
+  priority: FlowPriority;
+  status: FlowStatus;
+}
+
+const flow = {
+  priority: FlowPriority.High,  // Autocomplete, no typos
+  status: FlowStatus.Completed
+};
+```
+
+**When to use enums:**
+- Fixed sets of values (statuses, priorities, types, categories)
+- API response types that won't change frequently
+- UI states (loading, success, error, idle)
+- Button variants, sizes, or themes
+- Any value set that appears in multiple files
+
+**Enum organization:**
+```typescript
+// src/types/enums.ts
+export enum FlowPriority {
+  Low = 'low',
+  Medium = 'medium',
+  High = 'high'
+}
+
+export enum FlowStatus {
+  Pending = 'pending',
+  InProgress = 'in_progress',
+  Completed = 'completed'
+}
+
+export enum ContextType {
+  Work = 'work',
+  Personal = 'personal',
+  Rest = 'rest',
+  Social = 'social'
+}
+```
+
+**Benefits:**
+- **Autocomplete**: IDE suggests all valid values
+- **Type safety**: Prevents typos and invalid values
+- **Refactoring**: Rename enum value updates all usages
+- **Discoverability**: Easy to find all possible values
+- **Consistency**: Enforces same casing/spelling across codebase
+
+### 8. **Database Query Patterns**
 
 **Rule:** All MongoDB queries MUST use repository pattern with proper error handling.
 
@@ -343,5 +420,53 @@ from src.middleware.auth import get_current_user
 **All mappings are defined in `my_flow_client/src/app/globals.css` in the `@theme` block - verify there before using.**
 
 **See [`docs/token-system-update-2.0.md`](../token-system-update-2.0.md) for complete migration guide.**
+
+### 9. **Backend Enum Usage (Python)**
+
+**Rule:** Python backend MUST also use Enum classes for fixed value sets, matching frontend TypeScript enums.
+
+```python
+# ❌ WRONG: String literals
+from typing import Literal
+
+Priority = Literal["low", "medium", "high"]
+
+def create_flow(priority: Priority):
+    if priority == "high":  # Typo risk
+        ...
+
+# ✅ CORRECT: Use Python Enum
+from enum import Enum
+
+class FlowPriority(str, Enum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+def create_flow(priority: FlowPriority):
+    if priority == FlowPriority.HIGH:  # Type-safe
+        ...
+```
+
+**Pydantic integration:**
+```python
+from pydantic import BaseModel
+from enum import Enum
+
+class FlowPriority(str, Enum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+class FlowCreate(BaseModel):
+    title: str
+    priority: FlowPriority = FlowPriority.MEDIUM  # Default with enum
+```
+
+**Benefits:**
+- **API consistency**: Frontend and backend use same string values
+- **Validation**: Pydantic validates enum values automatically
+- **Type safety**: mypy catches invalid enum usage
+- **Documentation**: OpenAPI spec shows allowed values
 
 ---

--- a/docs/stories/2.1.story.md
+++ b/docs/stories/2.1.story.md
@@ -1,0 +1,288 @@
+# Story 2.1: Context & Flow Pydantic Models with MongoDB Schemas (BE)
+
+## Status
+Draft
+
+## Story
+
+**As a** backend developer,
+**I want** fully typed Pydantic models for Context and Flow entities with MongoDB schema definitions,
+**so that** we have strict type safety and validation for all data operations.
+
+## Acceptance Criteria
+
+1. **Pydantic models created in `my_flow_api/src/models/context.py`:**
+   - `ContextBase`, `ContextCreate`, `ContextUpdate`, `ContextInDB`, `ContextResponse`
+   - Fields: `id` (ObjectId), `user_id` (str), `name` (str, 1-50 chars), `color` (hex color), `icon` (str), `created_at` (datetime), `updated_at` (datetime)
+   - Validators for color hex format and icon emoji
+   - Config: `from_attributes = True`, `json_encoders` for ObjectId and datetime
+
+2. **Pydantic models created in `my_flow_api/src/models/flow.py`:**
+   - `FlowBase`, `FlowCreate`, `FlowUpdate`, `FlowInDB`, `FlowResponse`
+   - Fields: `id` (ObjectId), `context_id` (ObjectId), `title` (str, 1-200 chars), `description` (Optional[str]), `is_completed` (bool), `priority` (Literal["low", "medium", "high"]), `created_at`, `updated_at`, `completed_at` (Optional[datetime])
+   - Validators for title length and priority enum
+
+3. **MongoDB indexes defined:**
+   - Contexts collection: Index on `user_id`, compound index on `(user_id, created_at desc)`
+   - Flows collection: Index on `context_id`, compound index on `(context_id, is_completed, priority)`
+
+4. **Type exports created in `my_flow_api/src/models/__init__.py`:**
+   - All models properly exported for internal use
+
+5. **Unit tests created in `my_flow_api/tests/unit/models/test_context.py` and `test_flow.py`:**
+   - Validation tests for all fields (boundaries, invalid formats)
+   - Serialization/deserialization tests
+   - At least 90% coverage for model files
+
+## Tasks / Subtasks
+
+- [ ] **Task 1: Set up models directory structure** (AC: 1, 2, 4)
+  - [ ] Create `my_flow_api/src/models/` directory if not exists
+  - [ ] Create `__init__.py` for models package
+  - [ ] Create empty files: `context.py`, `flow.py`
+
+- [ ] **Task 2: Implement Context Pydantic models** (AC: 1)
+  - [ ] Create `ContextBase` with fields: name, color, icon
+  - [ ] Add Field validators: name (1-50 chars), color (hex regex pattern), icon (1-10 chars for emoji)
+  - [ ] Create `ContextCreate` inheriting from `ContextBase`
+  - [ ] Create `ContextUpdate` with optional fields (name, color, icon)
+  - [ ] Create `ContextInDB` extending `ContextBase` with id, user_id, created_at, updated_at
+  - [ ] Create `ContextResponse` as alias or identical to `ContextInDB` for API responses
+  - [ ] Add Config class with `from_attributes = True` and json_encoders for ObjectId/datetime
+  - [ ] Add example schema in `json_schema_extra`
+
+- [ ] **Task 3: Implement Flow Pydantic models** (AC: 2)
+  - [ ] Create `Priority` enum with values: low, medium, high
+  - [ ] Create `FlowStatus` enum with values: overdue, due_today, due_soon, normal (for future use)
+  - [ ] Create `FlowBase` with fields: title, description, priority, due_date, reminder_enabled
+  - [ ] Add Field validators: title (1-200 chars), priority default to "medium"
+  - [ ] Create `FlowCreate` extending `FlowBase` with context_id field
+  - [ ] Create `FlowUpdate` with all optional fields
+  - [ ] Create `FlowInDB` extending `FlowBase` with: id, context_id, user_id, is_completed, created_at, updated_at, completed_at
+  - [ ] Create `FlowResponse` as alias for `FlowInDB`
+  - [ ] Create `FlowWithStatus` extending `FlowInDB` with computed fields: status, days_until_due (for future service layer use)
+  - [ ] Add Config class with `from_attributes = True` and json_encoders
+
+- [ ] **Task 4: Export models from __init__.py** (AC: 4)
+  - [ ] Export all Context models from `models/__init__.py`
+  - [ ] Export all Flow models from `models/__init__.py`
+  - [ ] Verify clean imports work: `from src.models import Context, ContextCreate, Flow, FlowCreate`
+
+- [ ] **Task 5: Document MongoDB indexes** (AC: 3)
+  - [ ] Add docstring comment in `context.py` documenting required indexes
+  - [ ] Add docstring comment in `flow.py` documenting required indexes
+  - [ ] Note: Actual index creation will be in database.py (Story 2.2 dependency)
+
+- [ ] **Task 6: Write unit tests for Context models** (AC: 5)
+  - [ ] Create `tests/unit/models/test_context.py`
+  - [ ] Test valid ContextCreate with all fields
+  - [ ] Test ContextCreate validation failures: name too short, name too long, invalid color format, empty icon
+  - [ ] Test ContextUpdate with partial fields
+  - [ ] Test ContextInDB serialization to dict
+  - [ ] Test json_encoders for ObjectId and datetime
+  - [ ] Ensure 90%+ coverage for context.py
+
+- [ ] **Task 7: Write unit tests for Flow models** (AC: 5)
+  - [ ] Create `tests/unit/models/test_flow.py`
+  - [ ] Test valid FlowCreate with required and optional fields
+  - [ ] Test FlowCreate validation failures: title too short, title too long, invalid priority
+  - [ ] Test FlowUpdate with partial fields including due_date set to None
+  - [ ] Test FlowInDB serialization to dict
+  - [ ] Test default priority is "medium" when not provided
+  - [ ] Test reminder_enabled defaults to True
+  - [ ] Ensure 90%+ coverage for flow.py
+
+- [ ] **Task 8: Run tests and verify coverage** (AC: 5)
+  - [ ] Run pytest for model tests: `pytest tests/unit/models/ -v --cov=src/models`
+  - [ ] Verify 90%+ coverage threshold met
+  - [ ] Fix any failing tests or validation issues
+
+## Dev Notes
+
+### Testing Standards
+
+**Test file locations:**
+- Unit tests for models: `my_flow_api/tests/unit/models/`
+- Test file naming: `test_<module_name>.py` (e.g., `test_context.py`, `test_flow.py`)
+
+**Testing frameworks:**
+- pytest for test runner
+- pytest-asyncio for async test support (not needed for these pure Pydantic tests)
+- pytest-cov for coverage reporting
+
+**Testing requirements:**
+- 90% minimum coverage for model files
+- Test both valid and invalid inputs
+- Test field validators and boundaries
+- Test serialization/deserialization
+
+[Source: docs/architecture/13-testing-strategy.md#test-organization]
+
+### Data Models Specifications
+
+**Context Model Fields:**
+- `id`: MongoDB ObjectId (string representation)
+- `user_id`: string (from Logto JWT sub claim)
+- `name`: string, 1-50 characters
+- `color`: string, hex format (#RRGGBB), validated with regex `^#[0-9A-Fa-f]{6}$`
+- `icon`: string, emoji character (1-10 chars to support multi-byte emojis)
+- `created_at`: datetime (UTC)
+- `updated_at`: datetime (UTC)
+
+**Flow Model Fields:**
+- `id`: MongoDB ObjectId (string representation)
+- `context_id`: MongoDB ObjectId (foreign key to Context)
+- `user_id`: string (derived from context, used for authorization)
+- `title`: string, 1-200 characters
+- `description`: Optional[string]
+- `priority`: Literal["low", "medium", "high"], default "medium"
+- `is_completed`: boolean, default False
+- `due_date`: Optional[datetime] (ISO 8601 format)
+- `reminder_enabled`: boolean, default True (if due_date is set)
+- `created_at`: datetime (UTC)
+- `updated_at`: datetime (UTC)
+- `completed_at`: Optional[datetime] (UTC)
+
+[Source: docs/architecture/data-models.md#context-model, #flow-model]
+
+### Backend File Structure
+
+**Models directory:**
+```
+my_flow_api/src/models/
+├── __init__.py          # Export all models
+├── context.py           # Context Pydantic models
+└── flow.py              # Flow Pydantic models
+```
+
+**Test directory:**
+```
+my_flow_api/tests/unit/models/
+├── __init__.py
+├── test_context.py      # Context model tests
+└── test_flow.py         # Flow model tests
+```
+
+[Source: docs/architecture/source-tree.md#backend-structure]
+
+### Pydantic Model Patterns
+
+**Base model structure:**
+```python
+from pydantic import BaseModel, Field
+from datetime import datetime
+
+class ContextBase(BaseModel):
+    name: str = Field(..., min_length=1, max_length=50)
+    color: str = Field(..., pattern=r'^#[0-9A-Fa-f]{6}$')
+    icon: str = Field(..., min_length=1, max_length=10)
+
+class ContextCreate(ContextBase):
+    """Schema for creating a context."""
+    pass
+
+class ContextUpdate(BaseModel):
+    """Schema for updating a context (partial)."""
+    name: str | None = Field(None, min_length=1, max_length=50)
+    color: str | None = Field(None, pattern=r'^#[0-9A-Fa-f]{6}$')
+    icon: str | None = Field(None, min_length=1, max_length=10)
+
+class Context(ContextBase):
+    """Complete context schema with DB fields."""
+    id: str = Field(..., alias="_id")
+    user_id: str
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        populate_by_name = True
+        json_schema_extra = {
+            "example": {
+                "id": "507f1f77bcf86cd799439011",
+                "user_id": "logto_user_abc123",
+                "name": "Work",
+                "color": "#3B82F6",
+                "icon": "💼",
+                "created_at": "2025-09-30T10:00:00Z",
+                "updated_at": "2025-09-30T10:00:00Z",
+            }
+        }
+```
+
+[Source: docs/architecture/backend-architecture.md#pydantic-models-requestresponse-schemas]
+
+### MongoDB Index Documentation
+
+**Contexts collection indexes:**
+- Single field index on `user_id` for listing user's contexts
+- Compound index on `(user_id, created_at desc)` for sorted listing
+
+**Flows collection indexes:**
+- Single field index on `context_id` for listing flows within context
+- Compound index on `(context_id, is_completed, priority)` for filtered/sorted queries
+
+Note: Actual index creation happens in `database.py` during app startup (handled in Story 2.2)
+
+[Source: docs/architecture/data-models.md#database-indexes-mongodb]
+
+### Python Version and Dependencies
+
+**Python version:** 3.12+
+
+**Required dependencies:**
+- `pydantic ^2.8.0` - Data validation and settings
+- `pydantic-settings ^2.4.0` - Settings management
+
+**Dev dependencies:**
+- `pytest ^8.3.0` - Test framework
+- `pytest-cov` - Coverage reporting
+- `mypy ^1.11.0` - Static type checking
+
+[Source: docs/architecture/tech-stack.md, docs/architecture/backend-architecture.md#deployment-configuration]
+
+### Type Hints and Coding Standards
+
+**All functions must have complete type annotations:**
+```python
+def create_context(data: ContextCreate) -> Context:
+    ...
+```
+
+**Import order:**
+1. Standard library (datetime, typing)
+2. Third-party (pydantic, fastapi)
+3. Local application (from src.models import ...)
+
+**Naming conventions:**
+- Classes: PascalCase (e.g., `ContextCreate`, `FlowBase`)
+- Functions: snake_case (e.g., `validate_color`, `to_dict`)
+- Constants: UPPER_SNAKE (e.g., `DEFAULT_PRIORITY`)
+
+[Source: docs/architecture/coding-standards.md#naming-conventions]
+
+### No Previous Story Context
+
+This is the first story in Epic 2, so no previous story insights to incorporate.
+
+## Change Log
+
+| Date | Version | Description | Author |
+|------|---------|-------------|--------|
+| 2025-10-05 | 1.0 | Story created for Epic 2.1 | Bob (Scrum Master) |
+
+## Dev Agent Record
+
+### Agent Model Used
+<!-- To be filled by dev agent -->
+
+### Debug Log References
+<!-- To be filled by dev agent -->
+
+### Completion Notes List
+<!-- To be filled by dev agent -->
+
+### File List
+<!-- To be filled by dev agent -->
+
+## QA Results
+<!-- To be filled by QA agent -->

--- a/docs/stories/2.5.story.md
+++ b/docs/stories/2.5.story.md
@@ -1,0 +1,415 @@
+# Story 2.5: Context Switcher UI Component (FE)
+
+## Status
+Draft
+
+## Story
+
+**As a** frontend developer,
+**I want** a reusable Context Switcher component built with shadcn/ui,
+**so that** users can easily switch between contexts with visual distinction.
+
+## Acceptance Criteria
+
+1. **Context Switcher component created in `my_flow_client/src/components/contexts/context-switcher.tsx`:**
+   - Uses shadcn/ui `Select` component as base
+   - Displays context name, icon (emoji), and color indicator
+   - Shows current context with visual highlight
+   - Dropdown shows all user contexts sorted by most recently used
+
+2. **Styling uses Tailwind utility classes mapped to CSS design tokens:**
+   - Context colors use `bg-context`, `bg-context-work`, `bg-context-personal`, etc.
+   - Background colors use `bg-bg-secondary`
+   - Text colors use `text-text-primary` and `text-text-secondary`
+   - Spacing uses `space-md` and `space-sm` from Tailwind config
+   - No hardcoded colors or spacing values (use Tailwind utilities only)
+
+3. **Component props typed with TypeScript:**
+   ```typescript
+   interface ContextSwitcherProps {
+     currentContextId: string;
+     contexts: Context[];
+     onContextChange: (contextId: string) => void;
+     className?: string;
+   }
+   ```
+
+4. **Accessibility requirements met:**
+   - Keyboard navigable (Tab, Enter, Arrow keys)
+   - Screen reader labels for all interactive elements
+   - Focus states visible with context accent color border
+   - ARIA attributes: `role="combobox"`, `aria-label="Select context"`
+
+5. **Unit tests created in `my_flow_client/src/components/contexts/__tests__/context-switcher.test.tsx`:**
+   - Tests rendering with mock context data
+   - Tests keyboard navigation
+   - Tests `onContextChange` callback firing
+   - Tests accessibility with jest-axe
+   - At least 80% coverage
+
+6. **Storybook story created in `my_flow_client/src/components/contexts/context-switcher.stories.tsx` (Optional):**
+   - Shows component with 4 contexts (work, personal, rest, social)
+   - Shows selected state
+   - Shows disabled state
+   - Dark mode only (no light mode variant)
+
+## Tasks / Subtasks
+
+- [ ] **Task 1: Install and configure shadcn/ui Select component** (AC: 1)
+  - [ ] Check if shadcn/ui is already initialized in the project
+  - [ ] Run `npx shadcn@latest add select` to add Select component
+  - [ ] Verify Select component installed at `src/components/ui/select.tsx`
+
+- [ ] **Task 2: Create component directory and files** (AC: 1, 3)
+  - [ ] Create directory: `my_flow_client/src/components/contexts/`
+  - [ ] Create file: `context-switcher.tsx`
+  - [ ] Create test directory: `__tests__/`
+  - [ ] Create test file: `__tests__/context-switcher.test.tsx`
+
+- [ ] **Task 3: Define TypeScript interfaces** (AC: 3)
+  - [ ] Create `Context` type in `src/types/context.ts` (if not exists)
+  - [ ] Define fields: id (string), user_id (string), name (string), color (string), icon (string), created_at (string), updated_at (string)
+  - [ ] Create `ContextSwitcherProps` interface in component file
+  - [ ] Import and use proper types for all props and state
+
+- [ ] **Task 4: Implement basic Context Switcher component** (AC: 1, 2)
+  - [ ] Create functional component with shadcn/ui Select as base
+  - [ ] Accept props: currentContextId, contexts, onContextChange, className
+  - [ ] Render Select.Trigger showing current context name and icon
+  - [ ] Render Select.Content with all contexts as Select.Items
+  - [ ] Display context icon (emoji), name, and color indicator for each item
+  - [ ] Apply Tailwind utility classes ONLY (no `[var(--*)]` arbitrary values)
+  - [ ] Use `bg-bg-secondary`, `text-text-primary`, `text-text-secondary` from Tailwind config
+  - [ ] Add color indicator using `bg-context-work`, `bg-context-personal`, etc.
+
+- [ ] **Task 5: Implement context sorting logic** (AC: 1)
+  - [ ] Sort contexts by `updated_at` descending (most recently used first)
+  - [ ] Ensure current context is visually highlighted in dropdown
+  - [ ] Add visual separator or "Current" label for selected context
+
+- [ ] **Task 6: Implement accessibility features** (AC: 4)
+  - [ ] Add `role="combobox"` to Select component (may be default from shadcn/ui)
+  - [ ] Add `aria-label="Select context"` to Select.Trigger
+  - [ ] Add `aria-current="true"` to current context Select.Item
+  - [ ] Ensure keyboard navigation works: Tab (focus), Enter (open/select), Arrow keys (navigate)
+  - [ ] Add focus-visible ring using `ring-context` or `ring-2 ring-offset-2 ring-context`
+  - [ ] Test with keyboard only (no mouse) to verify full navigability
+
+- [ ] **Task 7: Write unit tests** (AC: 5)
+  - [ ] Install testing dependencies if needed: `@testing-library/react`, `@testing-library/user-event`, `vitest`
+  - [ ] Create test file with mock context data (4 contexts: work, personal, rest, social)
+  - [ ] Test: Component renders correctly with contexts
+  - [ ] Test: Current context is displayed in trigger
+  - [ ] Test: Clicking trigger opens dropdown with all contexts
+  - [ ] Test: Clicking a context calls `onContextChange` with correct ID
+  - [ ] Test: Keyboard navigation (ArrowDown, ArrowUp, Enter) works
+  - [ ] Test: Component has accessible labels and roles
+  - [ ] Install and configure `jest-axe` for accessibility testing
+  - [ ] Test: No accessibility violations detected by jest-axe
+  - [ ] Run coverage: `bun test --coverage` and verify 80%+ coverage
+
+- [ ] **Task 8: Create Storybook story (Optional)** (AC: 6)
+  - [ ] Check if Storybook is configured in project
+  - [ ] Create `context-switcher.stories.tsx` file
+  - [ ] Create story: "Default" with 4 contexts, "Work" selected
+  - [ ] Create story: "Personal Context Selected"
+  - [ ] Create story: "Disabled State" (if applicable)
+  - [ ] Run `bun run storybook` and verify stories render correctly
+
+- [ ] **Task 9: Integration test with mock data** (AC: 1, 2, 4)
+  - [ ] Create integration test that renders component with full context list
+  - [ ] Verify color indicators match context colors
+  - [ ] Verify sorting is correct (most recent first)
+  - [ ] Verify aria attributes are present
+  - [ ] Verify callback is invoked with correct parameters
+
+## Dev Notes
+
+### Testing Standards
+
+**Test file locations:**
+- Component tests: `my_flow_client/src/components/contexts/__tests__/`
+- Test file naming: `<component-name>.test.tsx` (e.g., `context-switcher.test.tsx`)
+
+**Testing frameworks:**
+- Vitest for test runner (configured as Bun Test alternative)
+- React Testing Library (`@testing-library/react`) for component testing
+- `@testing-library/user-event` for user interaction simulation
+- `jest-axe` for accessibility testing
+
+**Testing requirements:**
+- 80% minimum coverage for component files
+- Test rendering, user interactions, callbacks, and accessibility
+- Use `screen.getByRole()` queries for accessibility-focused tests
+
+[Source: docs/architecture/13-testing-strategy.md#frontend-tests]
+
+### Component Architecture
+
+**Component type:**
+- **Client Component** - Requires `'use client'` directive
+- Reason: Interactive state management (dropdown open/close, selection)
+- File should start with `'use client';` at the very top
+
+**Component location:**
+```
+my_flow_client/src/components/contexts/
+├── context-switcher.tsx        # Client Component
+└── __tests__/
+    └── context-switcher.test.tsx
+```
+
+[Source: docs/architecture/frontend-architecture.md#component-organization, docs/architecture/components.md#2-context-switcher-client-component]
+
+### Context Data Model
+
+**Context interface (TypeScript):**
+```typescript
+interface Context {
+  id: string;              // MongoDB ObjectId
+  user_id: string;         // Logto user ID
+  name: string;            // Display name (1-50 chars)
+  color: string;           // Hex color (#RRGGBB)
+  icon: string;            // Emoji character
+  created_at: string;      // ISO 8601 datetime
+  updated_at: string;      // ISO 8601 datetime
+}
+```
+
+**Example context data:**
+```typescript
+const mockContexts: Context[] = [
+  {
+    id: "ctx-work-123",
+    user_id: "user-1",
+    name: "Work",
+    color: "#3B82F6",
+    icon: "💼",
+    created_at: "2025-10-01T10:00:00Z",
+    updated_at: "2025-10-05T14:30:00Z"
+  },
+  {
+    id: "ctx-personal-456",
+    user_id: "user-1",
+    name: "Personal",
+    color: "#F97316",
+    icon: "🏠",
+    created_at: "2025-10-01T10:05:00Z",
+    updated_at: "2025-10-04T09:15:00Z"
+  }
+];
+```
+
+[Source: docs/architecture/data-models.md#context-model]
+
+### Tailwind CSS Variable Usage (CRITICAL)
+
+**MANDATORY: Use Tailwind utility classes, NOT arbitrary value syntax**
+
+The project uses a centralized Tailwind configuration that maps CSS custom properties to utility classes. You MUST use these utilities.
+
+**CORRECT approach (40-50% shorter):**
+```tsx
+<div className="bg-bg-primary text-text-primary border-border">
+  <button className="bg-button-primary text-button-text-primary shadow-sm">
+    Click Me
+  </button>
+</div>
+```
+
+**WRONG approach (verbose, avoid this):**
+```tsx
+<div className="bg-[var(--color-bg-primary)] text-[var(--color-text-primary)] border-[var(--color-border)]">
+  <button className="bg-[var(--button-bg-primary)] text-[var(--button-text-primary)] shadow-[var(--shadow-sm)]">
+    Click Me
+  </button>
+</div>
+```
+
+**Available Tailwind utilities for this component:**
+- Backgrounds: `bg-bg-primary`, `bg-bg-secondary`, `bg-bg-tertiary`
+- Text: `text-text-primary`, `text-text-secondary`, `text-text-muted`
+- Borders: `border-border`, `border-card-border`
+- Context colors: `bg-context`, `text-context`, `border-context`
+- Specific contexts: `bg-context-work`, `bg-context-personal`, `bg-context-rest`, `bg-context-social`
+- Buttons: `bg-button-primary`, `text-button-text-primary`
+- Cards: `bg-card`, `border-card-border`
+- Shadows: `shadow-sm`, `shadow-md`, `shadow-lg`
+
+All mappings defined in `my_flow_client/src/app/globals.css` in the `@theme` block.
+
+[Source: docs/architecture/coding-standards.md#8-tailwind-css-variable-usage]
+
+### shadcn/ui Select Component
+
+**Installation:**
+```bash
+npx shadcn@latest add select
+```
+
+**Basic usage pattern:**
+```tsx
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+
+<Select value={value} onValueChange={setValue}>
+  <SelectTrigger className="w-[200px]">
+    <SelectValue placeholder="Select option" />
+  </SelectTrigger>
+  <SelectContent>
+    <SelectItem value="option1">Option 1</SelectItem>
+    <SelectItem value="option2">Option 2</SelectItem>
+  </SelectContent>
+</Select>
+```
+
+**Accessibility:**
+- shadcn/ui Select is built on Radix UI Primitives
+- Automatically includes ARIA attributes: `role="combobox"`, `aria-expanded`, `aria-controls`
+- Keyboard navigation built-in: Tab, Enter, Arrow keys, Escape
+
+[Source: shadcn/ui documentation, docs/architecture/tech-stack.md]
+
+### Accessibility Requirements
+
+**Keyboard navigation:**
+- `Tab`: Focus on Select component
+- `Enter` or `Space`: Open dropdown
+- `ArrowDown` / `ArrowUp`: Navigate through options
+- `Enter`: Select highlighted option
+- `Escape`: Close dropdown
+
+**Screen reader support:**
+- `aria-label="Select context"` on SelectTrigger
+- `aria-current="true"` on current context item
+- Semantic HTML roles (SelectTrigger uses `button` role, SelectContent uses `listbox`)
+
+**Focus states:**
+- Visible focus ring using `ring-2 ring-context` or similar
+- Focus should use context accent color to match current theme
+
+[Source: docs/architecture/frontend-architecture.md#accessibility-considerations]
+
+### Import Order Standards
+
+```tsx
+// 1. External dependencies
+import { useState } from 'react';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+
+// 2. Internal absolute imports (@/ alias)
+import { cn } from '@/lib/utils';
+import type { Context } from '@/types/context';
+
+// 3. Relative imports
+import './context-switcher.css'; // if needed
+```
+
+[Source: docs/architecture/coding-standards.md#import-order-standards]
+
+### Component Implementation Pattern
+
+**File structure:**
+```tsx
+'use client';
+
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import type { Context } from '@/types/context';
+import { cn } from '@/lib/utils';
+
+interface ContextSwitcherProps {
+  currentContextId: string;
+  contexts: Context[];
+  onContextChange: (contextId: string) => void;
+  className?: string;
+}
+
+export function ContextSwitcher({
+  currentContextId,
+  contexts,
+  onContextChange,
+  className
+}: ContextSwitcherProps) {
+  // Sort contexts by updated_at descending
+  const sortedContexts = [...contexts].sort((a, b) =>
+    new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
+  );
+
+  const currentContext = contexts.find(c => c.id === currentContextId);
+
+  return (
+    <Select value={currentContextId} onValueChange={onContextChange}>
+      <SelectTrigger
+        className={cn("w-[200px]", className)}
+        aria-label="Select context"
+      >
+        <SelectValue>
+          {currentContext && (
+            <div className="flex items-center gap-2">
+              <span className="text-lg">{currentContext.icon}</span>
+              <span className="text-text-primary">{currentContext.name}</span>
+              <div
+                className="w-3 h-3 rounded-full"
+                style={{ backgroundColor: currentContext.color }}
+              />
+            </div>
+          )}
+        </SelectValue>
+      </SelectTrigger>
+      <SelectContent className="bg-bg-secondary border-border">
+        {sortedContexts.map((context) => (
+          <SelectItem
+            key={context.id}
+            value={context.id}
+            aria-current={context.id === currentContextId ? 'true' : undefined}
+            className="flex items-center gap-2 text-text-primary hover:bg-bg-tertiary"
+          >
+            <span className="text-lg">{context.icon}</span>
+            <span>{context.name}</span>
+            <div
+              className="w-3 h-3 rounded-full ml-auto"
+              style={{ backgroundColor: context.color }}
+            />
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+```
+
+**Note on color indicators:** The `backgroundColor: context.color` inline style is acceptable here because context colors are dynamic user data, not design tokens. For all other styling, use Tailwind utilities.
+
+[Source: docs/architecture/components.md#2-context-switcher-client-component, docs/architecture/frontend-architecture.md#react-server-components-strategy]
+
+### No Previous Story Context
+
+This is the first frontend story in Epic 2, so no previous story insights to incorporate. However, Story 2.1 (Backend Pydantic Models) is a parallel dependency that defines the Context data structure.
+
+## Change Log
+
+| Date | Version | Description | Author |
+|------|---------|-------------|--------|
+| 2025-10-05 | 1.0 | Story created for Epic 2.5 | Bob (Scrum Master) |
+
+## Dev Agent Record
+
+### Agent Model Used
+<!-- To be filled by dev agent -->
+
+### Debug Log References
+<!-- To be filled by dev agent -->
+
+### Completion Notes List
+<!-- To be filled by dev agent -->
+
+### File List
+<!-- To be filled by dev agent -->
+
+## QA Results
+<!-- To be filled by QA agent -->

--- a/docs/stories/2.5.story.md
+++ b/docs/stories/2.5.story.md
@@ -55,6 +55,14 @@ Draft
 
 ## Tasks / Subtasks
 
+- [ ] **Task 0: Audit codebase and implement TypeScript enums** (AC: All)
+  - [ ] Search entire `my_flow_client/src/` directory for hardcoded string literals that should be enums
+  - [ ] Identify repeated string values used for states, statuses, types, or categories
+  - [ ] Create enum definitions in appropriate type files (e.g., `src/types/enums.ts`)
+  - [ ] Replace all hardcoded string literals with enum values throughout the codebase
+  - [ ] Update existing TypeScript interfaces to use enum types instead of string literals
+  - [ ] Ensure all new code in this story uses enums for fixed value sets (e.g., context types, states, etc.)
+
 - [ ] **Task 1: Install and configure shadcn/ui Select component** (AC: 1)
   - [ ] Check if shadcn/ui is already initialized in the project
   - [ ] Run `npx shadcn@latest add select` to add Select component
@@ -396,6 +404,7 @@ This is the first frontend story in Epic 2, so no previous story insights to inc
 | Date | Version | Description | Author |
 |------|---------|-------------|--------|
 | 2025-10-05 | 1.0 | Story created for Epic 2.5 | Bob (Scrum Master) |
+| 2025-10-05 | 1.1 | Added Task 0: Enum audit and implementation | Bob (Scrum Master) |
 
 ## Dev Agent Record
 


### PR DESCRIPTION
## Summary

This PR adds the first parallel stories for Epic 2 (Context & Flow Data Layer) enabling simultaneous frontend and backend development:

- **Story 2.1 (BE)**: Context & Flow Pydantic Models with MongoDB Schemas
- **Story 2.5 (FE)**: Context Switcher UI Component

Additionally, establishes project-wide **enum usage standards** for type safety.

## Stories Added

### Story 2.1: Backend - Pydantic Models (docs/stories/2.1.story.md)
- Creates Pydantic models for Context and Flow entities
- Defines MongoDB schema and indexes
- 90% test coverage requirement
- 8 detailed tasks with comprehensive Dev Notes

### Story 2.5: Frontend - Context Switcher (docs/stories/2.5.story.md)
- Builds reusable Context Switcher component using shadcn/ui Select
- Implements Tailwind utility classes (no arbitrary values)
- 80% test coverage requirement
- **NEW: Task 0** - Audit codebase and implement TypeScript enums
- 9 detailed tasks with comprehensive Dev Notes

## Coding Standards Updates (docs/architecture/coding-standards.md)

### Section 7: TypeScript Enum Usage
- **Rule**: ALWAYS use enums for fixed value sets (statuses, priorities, types)
- Examples showing WRONG (string literals) vs CORRECT (enums)
- Benefits: autocomplete, type safety, refactoring support, consistency

### Section 9: Python Enum Usage
- Python Enum class patterns matching frontend TypeScript enums
- Pydantic integration for automatic validation
- Ensures API consistency between frontend and backend

## Benefits

✅ **Parallel Development**: Frontend and backend teams can work simultaneously  
✅ **Type Safety**: Enums prevent typos and invalid values across entire stack  
✅ **Consistency**: Same enum values in TypeScript and Python  
✅ **Comprehensive Guidance**: Detailed Dev Notes for AI dev agents  
✅ **Quality Gates**: Clear test coverage requirements (90% BE, 80% FE)

## Files Changed

- `docs/stories/2.1.story.md` - Backend Pydantic models story
- `docs/stories/2.5.story.md` - Frontend Context Switcher story  
- `docs/architecture/coding-standards.md` - Enum usage standards

## Next Steps

After merge, assign stories to dev agents:
- Story 2.1 → Backend dev agent
- Story 2.5 → Frontend dev agent