### PR TITLE
ci: enable Claude Code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,7 +12,6 @@ on:
 
 jobs:
   claude-review:
-    if: false # Temporarily disabled—no Claude credentials available
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||


### PR DESCRIPTION
Enable Claude Code automated PR reviews by removing the 'if: false' condition.

GitHub App authentication was configured via `/install-github-app` command.

This PR must be merged to main before the workflow can run on other PRs (this is normal GitHub Actions behavior).